### PR TITLE
Add Docker-based local dev setup with PostGIS support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+__pycache__/
+*.pyc
+*.pyo
+*.sqlite3
+venv/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ ENV/
 # Migrations
 migrations/
 .vagrant/
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list \
     libjpeg-dev \
     libpq-dev \
     libproj-dev \
+    postgresql-client \
     proj-bin \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
@@ -36,4 +37,5 @@ COPY . /app/
 ENV GDAL_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libgdal.so
 ENV GEOS_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libgeos_c.so
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3.6-slim-buster
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Debian buster is EOL; point apt at the archive to avoid 404s.
+RUN sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list \
+  && sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list \
+  && sed -i '/buster-updates/d' /etc/apt/sources.list \
+  && apt-get -o Acquire::Check-Valid-Until=false update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    gettext \
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    libjpeg-dev \
+    libpq-dev \
+    libproj-dev \
+    proj-bin \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/
+RUN pip install --upgrade "pip<21" "setuptools<58" wheel \
+  && pip install -r requirements.txt
+
+# Django 1.11 expects an older GEOS version string format.
+RUN sed -i "s/( r\\\\d.*/.*$'/" /usr/local/lib/python3.6/site-packages/django/contrib/gis/geos/libgeos.py
+
+COPY . /app/
+
+ENV GDAL_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libgdal.so
+ENV GEOS_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libgeos_c.so
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -28,20 +28,16 @@ If you prefer Docker for local development:
    ```bash
    docker compose up --build
    ```
-2. Create PostGIS extension and run migrations:
-   ```bash
-   docker compose exec db psql -U katika -d katika -c "CREATE EXTENSION IF NOT EXISTS postgis;"
-   docker compose exec web python manage.py migrate
-   ```
-3. (Optional) Create a superuser:
+2. (Optional) Create a superuser:
    ```bash
    docker compose exec web python manage.py createsuperuser
    ```
-4. Open http://localhost:8000
+3. Open http://localhost:8000
 
 Notes:
 - GeoDjango on Django 1.11 expects an older GEOS version string. The Dockerfile includes a small patch to avoid a startup error.
 - Database settings are configurable via environment variables: `DJANGO_DB_NAME`, `DJANGO_DB_USER`, `DJANGO_DB_PASSWORD`, `DJANGO_DB_HOST`, `DJANGO_DB_PORT`.
+- Migrations and sample data population run automatically on container startup. Set `DJANGO_RUN_MIGRATIONS=0` or `DJANGO_AUTO_POPULATE=0` to disable.
 
 ## Troubleshooting
 * To change how what port is exposed and, in general, OS stuff, check the Vagrantfile.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ Then after cloning the repo, cd to the root directory and run `vagrant up`.
 If everything goes well, a VM will be created, everything installed and Katika running in that VM on port 8000 which will be exposed to your host machine on port 8002.
 So head to http://localhost:8002
 
+## Docker / Docker Compose
+If you prefer Docker for local development:
+
+1. Build and start the containers:
+   ```bash
+   docker compose up --build
+   ```
+2. Create PostGIS extension and run migrations:
+   ```bash
+   docker compose exec db psql -U katika -d katika -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+   docker compose exec web python manage.py migrate
+   ```
+3. (Optional) Create a superuser:
+   ```bash
+   docker compose exec web python manage.py createsuperuser
+   ```
+4. Open http://localhost:8000
+
+Notes:
+- GeoDjango on Django 1.11 expects an older GEOS version string. The Dockerfile includes a small patch to avoid a startup error.
+- Database settings are configurable via environment variables: `DJANGO_DB_NAME`, `DJANGO_DB_USER`, `DJANGO_DB_PASSWORD`, `DJANGO_DB_HOST`, `DJANGO_DB_PORT`.
+
 ## Troubleshooting
 * To change how what port is exposed and, in general, OS stuff, check the Vagrantfile.
 * To see what is installed and how the DB (Postgres) is configured, check install.sh
@@ -36,6 +58,7 @@ Then head to http://localhost:8002/admin and access the management interface.
 _Here is an area where Django really shines._
 
 
+
 # Where do we think we need help?
 * Katika runs on an extremely tight budget, so we need to squeeze capacity/resource whenever possible. Let us know or just submit proposal on optimization ideas.
 * We think our UX/UI can be improved, so if you have front-end suggestions and would like to contribute, please do not hesitate
@@ -49,7 +72,3 @@ By giving back to the community, we hope to foster a stronger Dev ecosystem in C
 
 # License
 This code is free as in 'free beer'. It would be nice to reference the project when used but it is NOT required.
-
-
-
-

--- a/config_french_unaccent.sql
+++ b/config_french_unaccent.sql
@@ -1,5 +1,13 @@
-CREATE EXTENSION unaccent;
-CREATE TEXT SEARCH CONFIGURATION french_unaccent( COPY = french );
+CREATE EXTENSION IF NOT EXISTS unaccent;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_ts_config WHERE cfgname = 'french_unaccent'
+    ) THEN
+        CREATE TEXT SEARCH CONFIGURATION french_unaccent ( COPY = french );
+    END IF;
+END
+$$;
 ALTER TEXT SEARCH CONFIGURATION french_unaccent
 ALTER MAPPING FOR hword, hword_part, word
 WITH unaccent, french_stem;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     image: postgis/postgis:13-3.1
@@ -9,6 +7,7 @@ services:
       POSTGRES_PASSWORD: katika
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./config_french_unaccent.sql:/docker-entrypoint-initdb.d/01-french_unaccent.sql:ro
     ports:
       - "5432:5432"
 
@@ -20,6 +19,7 @@ services:
       DJANGO_DB_PASSWORD: katika
       DJANGO_DB_HOST: db
       DJANGO_DB_PORT: "5432"
+      DJANGO_AUTO_POPULATE: "1"
     volumes:
       - .:/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.8"
+
+services:
+  db:
+    image: postgis/postgis:13-3.1
+    environment:
+      POSTGRES_DB: katika
+      POSTGRES_USER: katika
+      POSTGRES_PASSWORD: katika
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  web:
+    build: .
+    environment:
+      DJANGO_DB_NAME: katika
+      DJANGO_DB_USER: katika
+      DJANGO_DB_PASSWORD: katika
+      DJANGO_DB_HOST: db
+      DJANGO_DB_PORT: "5432"
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+
+volumes:
+  postgres_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+DB_NAME="${DJANGO_DB_NAME:-katika}"
+DB_USER="${DJANGO_DB_USER:-katika}"
+DB_PASSWORD="${DJANGO_DB_PASSWORD:-katika}"
+DB_HOST="${DJANGO_DB_HOST:-db}"
+DB_PORT="${DJANGO_DB_PORT:-5432}"
+
+export PGPASSWORD="$DB_PASSWORD"
+
+if [ "${DJANGO_WAIT_FOR_DB:-1}" = "1" ]; then
+  echo "Waiting for database at ${DB_HOST}:${DB_PORT}..."
+  while ! pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" > /dev/null 2>&1; do
+    sleep 1
+  done
+fi
+
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 \
+  -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 \
+  -f /app/config_french_unaccent.sql
+
+if [ "${DJANGO_RUN_MIGRATIONS:-1}" = "1" ]; then
+  python manage.py migrate --noinput
+fi
+
+if [ "${DJANGO_AUTO_POPULATE:-1}" = "1" ]; then
+  python populate_db.py
+fi
+
+exec "$@"

--- a/katika/settings.py
+++ b/katika/settings.py
@@ -151,6 +151,12 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 # DATABASES #
 #############
 
+DB_NAME = os.environ.get("DJANGO_DB_NAME", "katika")
+DB_USER = os.environ.get("DJANGO_DB_USER", "vagrant")
+DB_PASSWORD = os.environ.get("DJANGO_DB_PASSWORD", "")
+DB_HOST = os.environ.get("DJANGO_DB_HOST", "")
+DB_PORT = os.environ.get("DJANGO_DB_PORT", "")
+
 DATABASES = {
     "default": {
         # Ends with "postgresql_psycopg2", "mysql", "sqlite3" or "oracle".
@@ -160,18 +166,21 @@ DATABASES = {
         "ENGINE": "django.contrib.gis.db.backends.postgis",
         # DB name or path to database file if using sqlite3.
         # "NAME": "dev.db",
-        "NAME": "katika",
+        "NAME": DB_NAME,
         #https://stackoverflow.com/questions/36214127/django-db-utils-operationalerror-fe-sendauth-no-password-supplied
         #"NAME": "",
         # Not used with sqlite3.
         # "USER": "postgres",
-        "USER": "vagrant",
+        "USER": DB_USER,
         # Not used with sqlite3.
         #"PASSWORD": "postgres",
+        "PASSWORD": DB_PASSWORD,
         # Set to empty string for localhost. Not used with sqlite3.
         #"HOST": "localhost",
+        "HOST": DB_HOST,
         # Set to empty string for default. Not used with sqlite3.
         #"PORT": "",
+        "PORT": DB_PORT,
     }
 }
 

--- a/populate_db.py
+++ b/populate_db.py
@@ -9,6 +9,8 @@ def populate():
 
 	from jailed.models import Prison
 	from django.contrib.gis.geos import GEOSGeometry
+	if Prison.objects.exists():
+		return
 	p = GEOSGeometry('POINT(4.06388 9.71237)', srid=4326)
 
 	p1 = Prison.objects.create(name="Japap", location=p)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ bleach==2.0.0
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-codegen==1.0
 decorator==4.1.2
 defusedxml==0.5.0
 Django==1.11


### PR DESCRIPTION
  - Add Dockerfile installing GeoDjango deps and patching GEOS version parsing for Django 1.11
  - Add docker-compose.yml with web + PostGIS services and DB env wiring
  - Add .dockerignore to keep images lean
  - Allow DB settings to be overridden via DJANGO_DB_* env vars in settings.py
  - Remove obsolete codegen==1.0 dependency (not referenced in repo)
  - Document Docker usage notes and env vars in README