### PR TITLE
Cleanup: Remove unused codegen package from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ bleach==2.0.0
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-codegen==1.0
 decorator==4.1.2
 defusedxml==0.5.0
 Django==1.11


### PR DESCRIPTION
As identified during the code review for the Docker integration, the 'codegen==1.0' package is currently included in requirements.txt but is not being utilized by any of the sub-projects (budget, covid19, incident, etc.).

Removing this dependency reduces the installation footprint and simplifies the environment setup.